### PR TITLE
feat(vts): 加入随机idle 动画、口型静止基线与VTS断线自动重连

### DIFF
--- a/src/modules/avatar/idle_motion_controller.py
+++ b/src/modules/avatar/idle_motion_controller.py
@@ -1,0 +1,424 @@
+"""
+IdleMotionController - VTS 默认拟人 idle 动画控制器
+
+在模型不说话时持续生成轻微头部/身体晃动，让 Live2D 形象更自然。
+说话时自动暂停/衰减，避免与口型同步冲突。
+
+运动生成采用"随机漫步"而非固定频率正弦：每个轴向随机目标点缓动，
+到位后随机停留或随机走向下一个目标（节奏、时长、幅度均不规则），
+更接近真人的微动作；身体按一定比例耦合头部运动，形成头身联动。
+"""
+
+import asyncio
+import random
+import time
+from typing import Any, Callable, Coroutine, Dict, Optional
+
+from src.modules.logging import get_logger
+
+
+def _smootherstep(x: float) -> float:
+    """smootherstep 缓动（0~1 两端速度与加速度均为 0，运动无顿挫）"""
+    x = min(1.0, max(0.0, x))
+    return x * x * x * (x * (x * 6 - 15) + 10)
+
+
+class AxisWander:
+    """单轴随机漫步器：随机目标 + 随机时长 + 随机停留。
+
+    每段运动：从当前值缓动到随机目标值（时长随机）；到位后以一定概率
+    停留随机时间（拟人的"静止间隙"），否则立即走向下一个随机目标。
+    目标值偏向中心（三角分布），约 20% 概率出现一次较大幅度动作。
+    """
+
+    def __init__(
+        self,
+        rng: random.Random,
+        *,
+        min_duration: float,
+        max_duration: float,
+        pause_probability: float,
+        max_pause: float,
+        min_target: float = 0.3,
+    ):
+        self._rng = rng
+        self._min_dur = min_duration
+        self._max_dur = max_duration
+        self._pause_prob = pause_probability
+        self._max_pause = max_pause
+        self._min_target = min_target
+
+        self._from = 0.0
+        self._to = 0.0
+        self._seg_start = 0.0
+        self._seg_dur = 1.0
+        self._pause_until = -1.0
+        self._initialized = False
+
+    def _new_target(self) -> float:
+        if self._rng.random() < 0.2:
+            mag = self._rng.uniform(0.7, 1.0)  # 偶尔一次较大幅度
+        else:
+            mag = abs(self._rng.triangular(-1.0, 1.0, 0.0))  # 偏向中心
+        mag = max(mag, self._min_target)
+        return mag if self._rng.random() < 0.5 else -mag
+
+    def _new_segment(self, t: float) -> None:
+        self._from = self._to
+        self._to = self._new_target()
+        self._seg_start = t
+        self._seg_dur = self._rng.uniform(self._min_dur, self._max_dur)
+
+    def value(self, t: float) -> float:
+        """t 时刻的归一化输出（约 -1.0 ~ 1.0）"""
+        if not self._initialized:
+            # 随机化初始进度，避免所有轴同时从 0 同步起步
+            self._initialized = True
+            self._new_segment(t)
+            self._seg_start = t - self._rng.uniform(0.0, self._seg_dur)
+
+        if self._pause_until > 0:
+            if t < self._pause_until:
+                return self._to
+            # 停留结束，走向下一个目标
+            self._pause_until = -1.0
+            self._new_segment(t)
+            return self._from
+
+        x = (t - self._seg_start) / max(self._seg_dur, 0.05)
+        if x >= 1.0:
+            current = self._to
+            if self._rng.random() < self._pause_prob:
+                self._pause_until = t + self._rng.uniform(0.3, self._max_pause)
+            else:
+                self._new_segment(t)
+            return current
+
+        return self._from + (self._to - self._from) * _smootherstep(x)
+
+
+class IdleMotionController:
+    """VTS 默认 idle 动画控制器"""
+
+    def __init__(
+        self,
+        *,
+        logger_name: str,
+        is_connected: Callable[[], bool],
+        is_speaking: Callable[[], bool],
+        set_parameter: Callable[[str, float], Coroutine[Any, Any, bool]],
+        param_head_x: str = "HeadAngleX",
+        param_head_y: str = "HeadAngleY",
+        param_head_z: str = "HeadAngleZ",
+        param_body_x: str = "BodyX",
+        param_body_y: str = "BodyY",
+        param_body_z: str = "BodyZ",
+        head_amplitude: float = 0.05,
+        body_amplitude: float = 0.02,
+        speed: float = 1.0,
+        update_interval_ms: float = 40.0,
+        fade_speed: float = 0.15,
+        head_enabled: bool = True,
+        body_enabled: bool = True,
+        speech_pause_enabled: bool = True,
+        extra_params: Optional[Dict[str, float]] = None,
+        extra_speed: Optional[float] = None,
+        rng: Optional[random.Random] = None,
+    ):
+        self._logger_name = logger_name
+        self.logger = get_logger(logger_name)
+        self._is_connected = is_connected
+        self._is_speaking = is_speaking
+        self._set_parameter = set_parameter
+
+        self._param_head_x = param_head_x
+        self._param_head_y = param_head_y
+        self._param_head_z = param_head_z
+        self._param_body_x = param_body_x
+        self._param_body_y = param_body_y
+        self._param_body_z = param_body_z
+
+        self._head_amplitude = max(0.0, head_amplitude)
+        self._body_amplitude = max(0.0, body_amplitude)
+        self._speed = max(0.1, speed)
+        self._interval = max(0.02, update_interval_ms / 1000.0)
+        self._fade_speed = max(0.05, min(1.0, fade_speed))
+        self._head_enabled = head_enabled
+        self._body_enabled = body_enabled
+        self._speech_pause_enabled = speech_pause_enabled
+
+        # 随机漫步器：每个轴独立的随机目标/时长/停留，运动节奏不规则。
+        # speed 通过缩放时长与停留生效（speed>1 整体更快）。
+        # 节奏取向：较快移动到目标位（短时长）+ 较长停留（拟人的"停顿感"）。
+        self._rng = rng or random.Random()
+        s = self._speed
+        es = max(0.1, extra_speed) if extra_speed is not None else s
+        self._wanders: Dict[str, AxisWander] = {
+            "head_x": AxisWander(
+                self._rng, min_duration=1.0 / s, max_duration=2.5 / s, pause_probability=0.55, max_pause=3.5 / s
+            ),
+            "head_y": AxisWander(
+                self._rng, min_duration=1.2 / s, max_duration=3.0 / s, pause_probability=0.55, max_pause=3.5 / s
+            ),
+            "head_z": AxisWander(
+                self._rng, min_duration=1.5 / s, max_duration=3.5 / s, pause_probability=0.60, max_pause=4.0 / s
+            ),
+            "body_x": AxisWander(
+                self._rng, min_duration=2.0 / s, max_duration=5.0 / s, pause_probability=0.60, max_pause=4.5 / s
+            ),
+            "body_y": AxisWander(
+                self._rng, min_duration=2.0 / s, max_duration=5.0 / s, pause_probability=0.60, max_pause=4.5 / s
+            ),
+            "body_z": AxisWander(
+                self._rng, min_duration=2.5 / s, max_duration=6.0 / s, pause_probability=0.65, max_pause=5.0 / s
+            ),
+        }
+
+        # 额外摆动参数（如自定义的袖子参数 SleeveRX/RY/LX/LY）：参数名 -> 幅度。
+        # 速度独立于头/身体（extra_speed），便于只加快头身而袖子保持不变。
+        self._extra_params: Dict[str, float] = {k: max(0.0, v) for k, v in (extra_params or {}).items() if k}
+        for name in self._extra_params:
+            self._wanders[f"extra:{name}"] = AxisWander(
+                self._rng, min_duration=1.5 / es, max_duration=4.0 / es, pause_probability=0.50, max_pause=4.0 / es
+            )
+
+        # 常驻基线参数（如 MouthSmile=base_smile）：每个 tick 持续写入，
+        # 防止外部（VTS 追踪/模型重载等）把一次性写入的值覆盖掉。
+        # 说话期间（LipSync 接管表情）或被当前 Intent 表情占用时不写入。
+        self._baseline_params: Dict[str, float] = {}
+        self._baseline_overrides: set[str] = set()
+
+        # 当前输出值（用于说话后平滑恢复）
+        self._current_values: Dict[str, float] = {}
+        # 目标基础值（未说话时）
+        self._target_values: Dict[str, float] = {}
+        # 说话期间使用 zero target
+        self._zero_target = {name: 0.0 for name in self._all_param_names()}
+
+        # 失败参数记录，避免重复刷屏日志
+        self._failed_params: set[str] = set()
+
+        self._task: Optional[asyncio.Task] = None
+        self._start_time = time.time()
+        self._running = False
+
+        self._log_shared_params()
+
+    def _all_param_names(self) -> list[str]:
+        names = []
+        if self._head_enabled:
+            names.extend([self._param_head_x, self._param_head_y, self._param_head_z])
+        if self._body_enabled:
+            names.extend([self._param_body_x, self._param_body_y, self._param_body_z])
+        names.extend(self._extra_params.keys())
+        # head/body 可能共享同一参数名（如模型脸部与身体绑定同一 tracking 输入），去重
+        return list(dict.fromkeys(n for n in names if n))
+
+    def set_parameter_names(
+        self,
+        *,
+        param_head_x: Optional[str] = None,
+        param_head_y: Optional[str] = None,
+        param_head_z: Optional[str] = None,
+        param_body_x: Optional[str] = None,
+        param_body_y: Optional[str] = None,
+        param_body_z: Optional[str] = None,
+    ) -> None:
+        """在 VTS 可用参数名解析后，动态更新控制器使用的参数名。"""
+        if param_head_x is not None:
+            self._param_head_x = param_head_x
+        if param_head_y is not None:
+            self._param_head_y = param_head_y
+        if param_head_z is not None:
+            self._param_head_z = param_head_z
+        if param_body_x is not None:
+            self._param_body_x = param_body_x
+        if param_body_y is not None:
+            self._param_body_y = param_body_y
+        if param_body_z is not None:
+            self._param_body_z = param_body_z
+
+        self._current_values.clear()
+        self._target_values.clear()
+        self._zero_target = {name: 0.0 for name in self._all_param_names()}
+        self._failed_params.clear()
+        self._log_shared_params()
+
+    def set_baseline_params(self, params: Dict[str, float]) -> None:
+        """设置常驻基线参数（如 MouthSmile=0.3），每 tick 持续维持。"""
+        self._baseline_params = {k: float(v) for k, v in (params or {}).items() if k}
+
+    def set_baseline_overrides(self, expressions: Dict[str, float]) -> None:
+        """设置当前 Intent 占用的表情参数名：这些参数不写入基线值。"""
+        self._baseline_overrides = set((expressions or {}).keys())
+
+    def _head_param_names(self) -> list[str]:
+        return [n for n in (self._param_head_x, self._param_head_y, self._param_head_z) if n]
+
+    def _body_param_names(self) -> list[str]:
+        return [n for n in (self._param_body_x, self._param_body_y, self._param_body_z) if n]
+
+    def _log_shared_params(self) -> None:
+        """head/body 使用相同参数名时提示：两路信号将叠加合并写入同一参数。"""
+        if not (self._head_enabled and self._body_enabled):
+            return
+        shared = sorted(set(self._head_param_names()) & set(self._body_param_names()))
+        if shared:
+            self.logger.info(
+                f"idle head/body 共享参数 {shared}（模型的脸部与身体绑定到同一 tracking 输入），"
+                f"两路 idle 信号将叠加合并写入。"
+            )
+
+    def start(self) -> None:
+        """启动 idle 动画后台循环"""
+        if self._running:
+            return
+        self._running = True
+        self._start_time = time.time()
+        self._task = asyncio.create_task(self._loop())
+        self._task.set_name(f"{self._logger_name}.idle_loop")
+        self.logger.info("VTS idle 动画已启动")
+
+    async def stop(self) -> None:
+        """停止 idle 动画后台循环，并把参数归零"""
+        if not self._running:
+            return
+        self._running = False
+
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+
+        # 把参数归零
+        for name in self._all_param_names():
+            if self._is_connected() and name:
+                try:
+                    await self._set_parameter(name, 0.0)
+                except Exception as e:
+                    self.logger.warning(f"idle 停止归零失败 {name}: {e}")
+        self._current_values.clear()
+        self._failed_params.clear()
+        self.logger.info("VTS idle 动画已停止")
+
+    async def _loop(self) -> None:
+        """后台循环：持续生成并发送 idle 参数"""
+        try:
+            while self._running:
+                await asyncio.sleep(self._interval)
+                if not self._is_connected():
+                    continue
+
+                try:
+                    is_speaking = self._is_speaking()
+                except Exception as e:
+                    self.logger.warning(f"获取说话状态失败: {e}")
+                    is_speaking = False
+
+                # 计算目标值
+                if self._speech_pause_enabled and is_speaking:
+                    targets = self._zero_target
+                else:
+                    targets = self._compute_targets(speaking=is_speaking)
+
+                # 平滑插值到目标值
+                for name, target in targets.items():
+                    current = self._current_values.get(name, 0.0)
+                    diff = target - current
+                    if abs(diff) < 0.001:
+                        new_value = target
+                    else:
+                        new_value = current + diff * self._fade_speed
+                    self._current_values[name] = new_value
+
+                    # 基线参数每 tick 强制写入，防止被外部覆盖后无法纠正
+                    force = name in self._baseline_params
+                    if force or abs(new_value - current) >= 0.0005 or abs(new_value) < 0.001:
+                        if name in self._failed_params:
+                            continue
+                        try:
+                            success = await self._set_parameter(name, new_value)
+                            if not success:
+                                self._failed_params.add(name)
+                                self.logger.warning(
+                                    f"idle 参数 {name} 设置未成功，可能是模型中不存在该参数；"
+                                    f"已暂停对此参数的 idle 写入，请检查 [handlers.vts] idle 参数名配置。"
+                                )
+                        except Exception as e:
+                            self._failed_params.add(name)
+                            self.logger.warning(
+                                f"idle 参数 {name} 写入失败: {e}。"
+                                f"已暂停对此参数的 idle 写入，请检查模型是否支持该参数。"
+                            )
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self.logger.error(f"idle 动画后台循环异常: {e}", exc_info=True)
+
+    def _compute_targets(self, speaking: bool = False) -> Dict[str, float]:
+        """计算当前时刻的目标 idle 参数值（随机漫步，归一化值 × 各轴幅度）
+
+        Args:
+            speaking: 是否正在说话。说话期间不写入基线表情参数
+                      （此时表情由 LipSync/Intent 接管，避免互相打架）。
+        """
+        t = time.time() - self._start_time
+        targets: Dict[str, float] = {}
+        hx = hy = hz = 0.0
+
+        if self._head_enabled:
+            # 头部：随机目标点之间缓动，节奏不规则（动-停-动）
+            hx = self._wanders["head_x"].value(t)
+            hy = self._wanders["head_y"].value(t)
+            hz = 0.6 * self._wanders["head_z"].value(t)
+            targets[self._param_head_x] = hx * self._head_amplitude
+            targets[self._param_head_y] = hy * self._head_amplitude * 0.6
+            # 歪头（顺时针/逆时针旋转）需要更大角度才可见，且模型该通道平滑度高
+            targets[self._param_head_z] = hz * self._head_amplitude * 2.5
+
+        if self._body_enabled:
+            # 身体：自身低频漫步 + 按 0.45 比例耦合头部波形（头动带动身体）
+            couple = 0.45
+            bx = 0.7 * self._wanders["body_x"].value(t) + couple * hx
+            by = 0.5 * self._wanders["body_y"].value(t) + couple * hy
+            bz = 0.3 * self._wanders["body_z"].value(t) + couple * hz
+            # 部分模型把脸部与身体绑定到同一 tracking 输入（如都用 FaceAngleX），
+            # 此时与头部信号叠加合并写入，而不是覆盖头部值。
+            self._merge_target(targets, self._param_body_x, bx * self._body_amplitude)
+            self._merge_target(targets, self._param_body_y, by * self._body_amplitude * 0.6)
+            self._merge_target(targets, self._param_body_z, bz * self._body_amplitude * 0.4)
+
+        # 额外摆动参数（如袖子）：独立随机漫步，幅度由配置给定
+        for name, amplitude in self._extra_params.items():
+            self._merge_target(targets, name, self._wanders[f"extra:{name}"].value(t) * amplitude)
+
+        # 常驻基线参数（如 MouthSmile）：说话期间或被当前 Intent 表情占用时不写入
+        if not speaking:
+            for name, value in self._baseline_params.items():
+                if name in targets or name in self._baseline_overrides:
+                    continue
+                targets[name] = value
+
+        return targets
+
+    def _merge_target(self, targets: Dict[str, float], name: str, value: float) -> None:
+        """写入 body 目标值；参数名已被 head 占用时叠加并钳制，避免覆盖头部信号。"""
+        if not name:
+            return
+        if name in targets:
+            limit = self._head_amplitude + self._body_amplitude
+            targets[name] = max(-limit, min(limit, targets[name] + value))
+        else:
+            targets[name] = value
+
+    def get_stats(self) -> Dict[str, Any]:
+        """返回统计信息"""
+        return {
+            "running": self._running,
+            "head_enabled": self._head_enabled,
+            "body_enabled": self._body_enabled,
+            "current_values": dict(self._current_values),
+        }

--- a/src/modules/streaming/audio_stream_channel.py
+++ b/src/modules/streaming/audio_stream_channel.py
@@ -28,9 +28,12 @@ class AudioStreamChannel:
         self.name = name
         self._logger = get_logger(f"AudioStreamChannel.{name}")
 
-        # 订阅者存储: {sub_id: (config, callbacks, queue)}
+        # 订阅者存储: {sub_id: {config, callbacks, queue}}
         self._subscribers: Dict[str, Dict[str, Any]] = {}
         self._lock = asyncio.Lock()
+
+        # 消费者任务: {sub_id: asyncio.Task}
+        self._consumer_tasks: Dict[str, asyncio.Task] = {}
 
         # 统计信息
         self._publish_count = 0
@@ -42,9 +45,26 @@ class AudioStreamChannel:
         self._is_started = True
         self._logger.info(f"AudioStreamChannel '{self.name}' 已启动")
 
+        # 为已存在的订阅者启动消费者
+        async with self._lock:
+            for sub_id in list(self._subscribers.keys()):
+                self._start_consumer(sub_id)
+
     async def stop(self) -> None:
         """停止通道并清理所有订阅者"""
         self._is_started = False
+
+        # 取消所有消费者任务
+        tasks = []
+        async with self._lock:
+            for _sub_id, task in list(self._consumer_tasks.items()):
+                if not task.done():
+                    task.cancel()
+                    tasks.append(task)
+            self._consumer_tasks.clear()
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
         async with self._lock:
             # 清空所有队列
@@ -107,17 +127,62 @@ class AudioStreamChannel:
         async with self._lock:
             self._subscribers[sub_id] = sub_data
 
+        # 启动消费者任务
+        self._start_consumer(sub_id)
+
         self._logger.info(f"订阅者 '{name}' 已注册 (ID: {sub_id})")
         return sub_id
 
     async def unsubscribe(self, sub_id: str) -> bool:
-        """取消订阅"""
         async with self._lock:
-            if sub_id in self._subscribers:
-                del self._subscribers[sub_id]
-                self._logger.info(f"订阅者 '{sub_id}' 已取消")
-                return True
-        return False
+            if sub_id not in self._subscribers:
+                return False
+
+            # 取消消费者任务
+            task = self._consumer_tasks.pop(sub_id, None)
+            if task and not task.done():
+                task.cancel()
+
+            del self._subscribers[sub_id]
+
+        if task and not task.done():
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        self._logger.info(f"订阅者 '{sub_id}' 已取消")
+        return True
+
+    def _start_consumer(self, sub_id: str) -> None:
+        """启动指定订阅者的消费者任务"""
+        if sub_id in self._consumer_tasks:
+            return
+
+        task = asyncio.create_task(self._run_consumer(sub_id))
+        self._consumer_tasks[sub_id] = task
+        self._logger.debug(f"订阅者 {sub_id} 消费者任务已启动")
+
+    async def _run_consumer(self, sub_id: str) -> None:
+        """消费者循环：从队列取音频块并调用回调"""
+        sub_data = self._subscribers.get(sub_id)
+        if not sub_data:
+            return
+
+        queue = sub_data["queue"]
+        callback = sub_data["callbacks"].get("chunk")
+        if not callback:
+            return
+
+        while True:
+            try:
+                chunk = await queue.get()
+                await callback(chunk)
+                queue.task_done()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self._logger.error(f"消费者处理音频块失败 ({sub_id}): {e}")
 
     async def notify_start(self, metadata: AudioMetadata) -> PublishResult:
         """通知所有订阅者：音频流开始"""

--- a/src/stages/output/handlers/avatar/vts/expression_controller.py
+++ b/src/stages/output/handlers/avatar/vts/expression_controller.py
@@ -4,7 +4,7 @@ ExpressionController - VTS 表情/参数控制器
 负责 VTS 表情参数读写（微笑、眨眼、参数设置/获取）。
 """
 
-from typing import Any, Callable, Coroutine, Optional
+from typing import Any, Callable, Coroutine, Dict, List, Optional
 
 from src.modules.logging import get_logger
 
@@ -61,21 +61,27 @@ class ExpressionController:
             self.logger.error(f"睁眼失败: {e}")
             return False
 
-    async def set_parameter(self, parameter_name: str, value: float, weight: float = 1) -> bool:
+    async def set_parameter(
+        self, parameter_name: str, value: float, weight: float = 1, *, silent: bool = False
+    ) -> bool:
         if not self._is_connected():
-            self.logger.warning(f"VTS未连接，无法设置参数: {parameter_name} = {value}")
+            if not silent:
+                self.logger.warning(f"VTS未连接，无法设置参数: {parameter_name} = {value}")
             return False
         try:
             response = await self._vts_request(
                 self._vts_request.vts_request.requestSetParameterValue(parameter_name, value, weight)
             )
             if response and response.get("messageType") == "InjectParameterDataResponse":
-                self.logger.debug(f"VTS参数 {parameter_name} 已设置为: {value}")
+                if not silent:
+                    self.logger.debug(f"VTS参数 {parameter_name} 已设置为: {value}")
                 return True
-            self.logger.warning(f"设置VTS参数失败: {parameter_name}: {response}")
+            if not silent:
+                self.logger.warning(f"设置VTS参数失败: {parameter_name}: {response}")
             return False
         except Exception as e:
-            self.logger.error(f"设置VTS参数异常: {parameter_name}: {e}")
+            if not silent:
+                self.logger.error(f"设置VTS参数异常: {parameter_name}: {e}")
             return False
 
     async def get_parameter(self, parameter_name: str) -> Optional[float]:
@@ -90,3 +96,72 @@ class ExpressionController:
         except Exception as e:
             self.logger.error(f"获取VTS参数异常: {parameter_name}: {e}")
             return None
+
+    async def list_tracking_parameters(self) -> List[str]:
+        """获取 VTS 当前可用参数名列表（含自定义与跟踪参数）。
+
+        用于 idle 动画等场景自动回退到可用参数名。
+        注意：VTS 对该请求的响应 messageType 为 InputParameterListResponse，
+        参数分布在 data.defaultParameters / data.customParameters 两个列表中。
+        """
+        if not self._is_connected():
+            return []
+        try:
+            response = await self._vts_request(self._vts_request.vts_request.requestTrackingParameterList())
+            if response and response.get("messageType") in (
+                "InputParameterListResponse",
+                "TrackingParameterListResponse",
+            ):
+                data = response.get("data", {})
+                # 新版响应：defaultParameters + customParameters；旧版：model_parameters
+                params = (
+                    data.get("defaultParameters", [])
+                    + data.get("customParameters", [])
+                    + data.get("model_parameters", [])
+                )
+                return [str(p.get("name")) for p in params if p.get("name")]
+            self.logger.warning(f"获取VTS参数列表失败: {response}")
+            return []
+        except Exception as e:
+            self.logger.error(f"获取VTS参数列表异常: {e}")
+            return []
+
+    async def set_multi_parameter(
+        self,
+        parameter_values: Dict[str, float],
+        weight: float = 1,
+        *,
+        silent: bool = False,
+    ) -> bool:
+        """一次性设置多个 VTS 参数值，减少 API 往返。
+
+        Args:
+            parameter_values: 参数名 -> 目标值。
+            weight: 与 VTS 自身跟踪/其他输入的混合权重；默认 1 表示完全覆盖。
+            silent: 失败时是否静默（避免刷屏）。
+
+        Returns:
+            是否全部设置成功。
+        """
+        if not parameter_values:
+            return True
+        if not self._is_connected():
+            if not silent:
+                self.logger.warning("VTS未连接，无法批量设置参数")
+            return False
+        names = list(parameter_values.keys())
+        values = list(parameter_values.values())
+        try:
+            response = await self._vts_request(
+                self._vts_request.vts_request.requestSetMultiParameterValue(names, values, weight)
+            )
+            if response and response.get("messageType") == "InjectParameterDataResponse":
+                self.logger.debug(f"VTS 多参数已设置: {names}")
+                return True
+            if not silent:
+                self.logger.warning(f"批量设置VTS参数失败: {names}: {response}")
+            return False
+        except Exception as e:
+            if not silent:
+                self.logger.error(f"批量设置VTS参数异常: {names}: {e}")
+            return False

--- a/src/stages/output/handlers/avatar/vts/hotkey_matcher.py
+++ b/src/stages/output/handlers/avatar/vts/hotkey_matcher.py
@@ -70,7 +70,8 @@ class HotkeyMatcher:
             self.logger.warning("VTS未连接，跳过加载热键列表")
             return
         try:
-            response = await self._vts_request.requestHotKeyList()
+            request_msg = self._vts_request.vts_request.requestHotKeyList()
+            response = await self._vts_request(request_msg)
             if response and response.get("data") and "availableHotkeys" in response["data"]:
                 hotkeys = response["data"]["availableHotkeys"]
                 self.hotkey_list = hotkeys
@@ -87,7 +88,7 @@ class HotkeyMatcher:
             return False
         try:
             self.logger.debug(f"触发热键: {hotkey_id}")
-            request_msg = self._vts_request.requestTriggerHotKey(hotkeyID=hotkey_id)
+            request_msg = self._vts_request.vts_request.requestTriggerHotKey(hotkeyID=hotkey_id)
             response = await self._vts_request(request_msg)
             if response and response.get("messageType") == "HotkeyTriggerResponse":
                 self.logger.debug(f"热键 {hotkey_id} 触发成功")

--- a/src/stages/output/handlers/avatar/vts/lip_sync_processor.py
+++ b/src/stages/output/handlers/avatar/vts/lip_sync_processor.py
@@ -5,6 +5,7 @@ LipSyncProcessor - VTS 口型同步处理器
 """
 
 import asyncio
+import time
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, Optional
 
 from src.modules.logging import get_logger
@@ -26,7 +27,22 @@ class LipSyncProcessor:
         vowel_detection_sensitivity: float,
         vts_set_parameter: Callable[..., Coroutine[Any, Any, bool]],
         is_connected: Callable[[], bool],
+        volume_gain: float = 1.0,
+        max_mouth_open: float = 0.85,
+        silence_threshold: float = 0.02,
+        close_mouth_threshold: float = 0.06,
+        power_curve: float = 0.6,
+        vowel_open_weight: float = 0.7,
+        update_interval_ms: float = 30.0,
+        analysis_window_ms: float = 60.0,
+        loop_interval_ms: float = 40.0,
+        expression_fade_speed: float = 0.15,
+        mouth_open_lerp_speed: float = 0.35,
+        vowel_decay: float = 0.4,
+        min_mouth_delta: float = 0.005,
+        expression_rest_values: Optional[Dict[str, float]] = None,
     ):
+        self._logger_name = logger_name
         self.logger = get_logger(logger_name)
         self._sample_rate = sample_rate
         self._volume_threshold = volume_threshold
@@ -35,9 +51,42 @@ class LipSyncProcessor:
         self._set_parameter = vts_set_parameter
         self._is_connected = is_connected
 
+        # 口型自然度参数
+        self._volume_gain = volume_gain
+        self._max_mouth_open = max_mouth_open
+        self._silence_threshold = silence_threshold
+        self._close_mouth_threshold = close_mouth_threshold
+        self._power_curve = power_curve
+        self._vowel_open_weight = vowel_open_weight
+        self._update_interval = update_interval_ms / 1000.0
+
+        # 分析窗口与循环间隔
+        self._analysis_window_seconds = analysis_window_ms / 1000.0
+        self._loop_interval = loop_interval_ms / 1000.0
+        self._max_buffer_seconds = 2.0  # 保留最近 2 秒音频避免内存无限增长
+
+        # 表情基础值与淡出速度
+        self._expression_fade_speed = expression_fade_speed
+        self._base_expressions: Dict[str, float] = {}
+        self._current_expression_values: Dict[str, float] = {}
+        # 各表情参数的"静止值"：说完话淡出到这个值而不是 0。
+        # 例如 EyeOpen* 的静止值必须是 1.0（睁眼），0 会变成闭眼；
+        # MouthSmile 可配置为常驻微笑基线，避免说完话瞬间变"撇嘴"。
+        self._expression_rest_values: Dict[str, float] = dict(expression_rest_values or {})
+        self._last_expression_update_time = 0.0
+        self._expression_update_interval = update_interval_ms / 1000.0
+
+        # 嘴型平滑参数
+        self._mouth_open_lerp_speed = mouth_open_lerp_speed
+        self._vowel_decay = vowel_decay
+        self._min_mouth_delta = min_mouth_delta
+        self._target_mouth_open = 0.0
+
         self.is_speaking = False
         self.current_vowel_values: Dict[str, float] = {"A": 0.0, "I": 0.0, "U": 0.0, "E": 0.0, "O": 0.0}
         self.current_volume = 0.0
+        self.current_mouth_open = 0.0
+        self._target_mouth_open = 0.0
         self.audio_analysis_lock = asyncio.Lock()
 
         self.vowel_formants = {
@@ -51,6 +100,8 @@ class LipSyncProcessor:
         self.accumulated_audio = bytearray()
         self.accumulation_start_time: Optional[float] = None
         self.audio_playback_start_time: Optional[float] = None
+        self._last_update_time = 0.0
+        self._lip_sync_task: Optional[asyncio.Task] = None
 
     async def on_start(self, metadata: "AudioMetadata") -> None:
         """AudioStreamChannel: 音频流开始回调"""
@@ -78,11 +129,26 @@ class LipSyncProcessor:
         self.logger.debug("收到音频流结束通知")
         await self.stop_session()
 
+    def _rest_value(self, name: str) -> float:
+        """参数的静止值（未配置时为 0.0）"""
+        return self._expression_rest_values.get(name, 0.0)
+
+    def set_base_expressions(self, expressions: Dict[str, float]) -> None:
+        """设置说话时保持的基础表情（如 MouthSmile），会自动过滤 MouthOpen"""
+        filtered = {}
+        for name, value in (expressions or {}).items():
+            if name == "MouthOpen":
+                continue
+            filtered[name] = float(value)
+        self._base_expressions = filtered
+        # 初始化当前值（从静止值起步），让后续平滑过渡
+        for name, _value in filtered.items():
+            self._current_expression_values.setdefault(name, self._rest_value(name))
+        self.logger.debug(f"LipSync 基础表情已设置: {filtered}")
+
     async def start_session(self, text: str = "") -> None:
         if self.is_speaking:
             await self.stop_session()
-
-        import time
 
         self.is_speaking = True
         self.audio_playback_start_time = time.time()
@@ -90,35 +156,73 @@ class LipSyncProcessor:
         self.accumulated_audio = bytearray()
         self.current_vowel_values = {"A": 0.0, "I": 0.0, "U": 0.0, "E": 0.0, "O": 0.0}
         self.current_volume = 0.0
+        self.current_mouth_open = 0.0
+        self._target_mouth_open = 0.0
+        self._last_update_time = 0.0
+        self._last_expression_update_time = 0.0
+
+        # 启动后台口型更新循环，按真实时间持续分析音频
+        self._lip_sync_task = asyncio.create_task(self._lip_sync_loop())
+        self._lip_sync_task.set_name(f"{self._logger_name}.lip_sync_loop")
 
     async def process_audio(self, audio_data: bytes, sample_rate: int = 32000) -> None:
         if not self.is_speaking:
             return
+        # 仅快速追加数据，实际分析在独立后台循环中进行，避免阻塞音频流
         async with self.audio_analysis_lock:
             self.accumulated_audio.extend(audio_data)
-            await self._analyze_audio_state()
+            self._trim_audio_buffer()
+
+    def _trim_audio_buffer(self) -> None:
+        """仅保留最近一段时间的音频，防止内存无限增长"""
+        max_bytes = int(self._max_buffer_seconds * self._sample_rate * 2)  # int16 = 2 bytes
+        if len(self.accumulated_audio) > max_bytes:
+            self.accumulated_audio = self.accumulated_audio[-max_bytes:]
+
+    def _has_active_expressions(self) -> bool:
+        """是否还有未回到静止值的表情，用于停止后继续淡出"""
+        return any(abs(v - self._rest_value(name)) > 0.01 for name, v in self._current_expression_values.items())
+
+    async def _lip_sync_loop(self) -> None:
+        """后台口型更新循环：按真实时间定期分析最近音频"""
+        try:
+            # 即使 is_speaking 结束，也继续运行直到表情淡出完成
+            while self.is_speaking or self._has_active_expressions():
+                await self._analyze_audio_state()
+                await asyncio.sleep(self._loop_interval)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self.logger.error(f"口型同步后台循环异常: {e}", exc_info=True)
 
     async def _analyze_audio_state(self) -> None:
-        if len(self.accumulated_audio) < 1024:
-            return
+        volume = 0.0
+        vowel_values: Dict[str, float] = {}
 
-        try:
-            import numpy as np
-
-            audio_array = np.frombuffer(self.accumulated_audio, dtype=np.int16).astype(np.float32)
-            audio_array = audio_array / 32768.0
-
-            rms = float(np.sqrt(np.mean(audio_array**2)))
-            volume = min(1.0, rms * 10)
-
-            if volume > self._volume_threshold:
-                vowel_values = self._detect_vowels(audio_array, sample_rate=self._sample_rate)
+        if self.is_speaking:
+            try:
+                import numpy as np
+            except ImportError:
                 await self._update_lip_sync_parameters(volume, vowel_values)
+                return
 
-            self.accumulated_audio = bytearray()
-            self.accumulation_start_time = None
-        except ImportError:
-            pass
+            async with self.audio_analysis_lock:
+                buffer_len = len(self.accumulated_audio)
+                if buffer_len >= 1024:
+                    # 只分析最近一个窗口的音频，反应当前播放位置
+                    window_bytes = int(self._analysis_window_seconds * self._sample_rate * 2)
+                    audio_bytes = bytes(self.accumulated_audio[-window_bytes:])
+
+                    audio_array = np.frombuffer(audio_bytes, dtype=np.int16).astype(np.float32)
+                    audio_array = audio_array / 32768.0
+
+                    rms = float(np.sqrt(np.mean(audio_array**2)))
+                    volume = min(1.0, rms * 6)
+
+                    if volume > self._volume_threshold * 0.3:
+                        vowel_values = self._detect_vowels(audio_array, sample_rate=self._sample_rate)
+
+        await self._update_lip_sync_parameters(volume, vowel_values)
 
     def _detect_vowels(self, audio_array, sample_rate: int = 16000) -> Dict[str, float]:
         try:
@@ -147,26 +251,141 @@ class LipSyncProcessor:
 
         return vowel_scores
 
+    async def _update_base_expressions(self, volume: float) -> None:
+        """说话时维持基础表情，静音或结束时向 0 淡出"""
+        if not self._base_expressions and not self._current_expression_values:
+            return
+
+        now = time.time()
+        if now - self._last_expression_update_time < self._expression_update_interval:
+            return
+        self._last_expression_update_time = now
+
+        # 说话时且音量足够，目标为基础表情值；否则淡出到静止值（眼睁/常驻微笑，而非一律归零）
+        if self.is_speaking and volume >= self._silence_threshold:
+            targets = self._base_expressions
+            speed = 0.35  # 说话期间较快达到目标
+        else:
+            targets = {name: self._rest_value(name) for name in self._current_expression_values}
+            speed = self._expression_fade_speed  # 静音/结束时较慢淡出
+
+        for name, target in targets.items():
+            current = self._current_expression_values.get(name, 0.0)
+            if abs(target - current) < 0.01:
+                new_value = target
+            else:
+                new_value = current + (target - current) * speed
+
+            self._current_expression_values[name] = new_value
+            if abs(new_value - current) >= 0.005:
+                await self._set_parameter(name, new_value, weight=1)
+
     async def _update_lip_sync_parameters(self, volume: float, vowel_values: Dict[str, float]) -> None:
+        now = time.time()
+
+        # 同步更新基础表情（说话保持/静音淡出），与口型更新频率独立
+        await self._update_base_expressions(volume)
+
+        # 限制 VTS 参数更新频率，避免过于抖动
+        if now - self._last_update_time < self._update_interval:
+            return
+        self._last_update_time = now
+
+        # 1. 先衰减已有元音值，让嘴巴能在音节间隙闭上
+        #    使用可配置衰减系数，较慢衰减让元音嘴型更连续
+        for vowel in self.current_vowel_values:
+            self.current_vowel_values[vowel] *= self._vowel_decay
+
+        # 2. 更新检测到的元音（取较大值，保持瞬时响应）
         for vowel, value in vowel_values.items():
-            new_value = self._smoothing_factor * value + (1 - self._smoothing_factor) * self.current_vowel_values.get(
+            smoothed = self._smoothing_factor * value + (1 - self._smoothing_factor) * self.current_vowel_values.get(
                 vowel, 0
             )
-            self.current_vowel_values[vowel] = new_value
+            self.current_vowel_values[vowel] = max(self.current_vowel_values[vowel], smoothed)
 
-        if "A" in self.current_vowel_values or "O" in self.current_vowel_values:
-            mouth_open = max(self.current_vowel_values.get("A", 0), self.current_vowel_values.get("O", 0))
-            await self._set_parameter("MouthOpen", mouth_open, weight=1)
+        # 3. 静音检测：音量极低时直接闭嘴
+        if volume < self._silence_threshold:
+            if self.current_mouth_open > 0.02:
+                await self._set_parameter("MouthOpen", 0.0, weight=1)
+                self.current_mouth_open = 0.0
+                self.logger.info(f"LipSync MouthOpen=0.000 (silence, volume={volume:.3f})")
+            self.current_volume = volume
+            return
 
+        # 4. 计算基于音量的张嘴幅度
+        #    使用幂曲线 + max_mouth_open 缩放，让嘴型更多分布在 0~0.5 区间，
+        #    只有强音才接近最大张嘴，避免长时间大张。
+        scaled_volume = min(1.0, volume * self._volume_gain)
+        volume_open = (scaled_volume**self._power_curve) * self._max_mouth_open
+
+        # 5. 计算元音张嘴幅度，只取开口元音 A/O，并受音量抑制
+        vowel_open = max(
+            self.current_vowel_values.get("A", 0),
+            self.current_vowel_values.get("O", 0),
+        )
+        vowel_open *= self._vowel_open_weight * (0.3 + 0.7 * volume)
+
+        # 6. 结合音量和元音
+        mouth_open = max(volume_open, vowel_open)
+
+        # 7. 低音量时额外衰减，让句子中的气口/停顿自然闭嘴
+        if volume < self._close_mouth_threshold:
+            mouth_open *= 0.2 + 0.8 * (volume / self._close_mouth_threshold)
+
+        # 8. 限制最大张嘴幅度
+        mouth_open = min(self._max_mouth_open, mouth_open)
+        self._target_mouth_open = mouth_open
+
+        # 9. 平滑过渡：每帧向目标值插值，避免嘴型跳变
+        lerp_speed = self._mouth_open_lerp_speed
+        # 闭嘴比张嘴稍快，让气口更干净
+        if mouth_open < self.current_mouth_open:
+            lerp_speed = min(0.8, lerp_speed * 1.6)
+        smoothed = self.current_mouth_open + (mouth_open - self.current_mouth_open) * lerp_speed
+
+        # 只有当变化足够大时才发送，但阈值很小以保证连续性
+        if abs(smoothed - self.current_mouth_open) < self._min_mouth_delta:
+            self.current_volume = volume
+            return
+
+        success = await self._set_parameter("MouthOpen", smoothed, weight=1)
+        self.current_mouth_open = smoothed
         self.current_volume = volume
+        self.logger.info(
+            f"LipSync MouthOpen={smoothed:.3f} (target={mouth_open:.3f}, volume={volume:.3f}, vowel={vowel_open:.3f}) success={success}"
+        )
 
     async def stop_session(self) -> None:
         if not self.is_speaking:
             return
         self.is_speaking = False
+
+        # 让后台循环继续运行，完成表情淡出
+        if self._lip_sync_task and not self._lip_sync_task.done():
+            try:
+                # 最多等待 2 秒让表情淡出完成
+                await asyncio.wait_for(self._lip_sync_task, timeout=2.0)
+            except asyncio.TimeoutError:
+                self._lip_sync_task.cancel()
+                try:
+                    await self._lip_sync_task
+                except asyncio.CancelledError:
+                    pass
+            except Exception:
+                pass
+        self._lip_sync_task = None
+
+        # 确保嘴巴归零、表情回到静止值（EyeOpen 保持睁眼、MouthSmile 保持常驻微笑）
         self.current_vowel_values = {"A": 0.0, "I": 0.0, "U": 0.0, "E": 0.0, "O": 0.0}
         self.current_volume = 0.0
+        self.current_mouth_open = 0.0
+        self._target_mouth_open = 0.0
         await self._set_parameter("MouthOpen", 0.0, weight=1)
+        for name in list(self._current_expression_values.keys()):
+            rest = self._rest_value(name)
+            if abs(self._current_expression_values[name] - rest) > 0.005:
+                await self._set_parameter(name, rest, weight=1)
+            self._current_expression_values[name] = rest
         self.accumulated_audio = bytearray()
         self.accumulation_start_time = None
         self.audio_playback_start_time = None

--- a/src/stages/output/handlers/avatar/vts/vts_handler.py
+++ b/src/stages/output/handlers/avatar/vts/vts_handler.py
@@ -10,7 +10,9 @@ VTS Handler - VTS虚拟形象渲染编排器
 - VTS 连接生命周期管理
 """
 
-from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import asyncio
 
 from pydantic import BaseModel, Field
 
@@ -21,6 +23,7 @@ from src.modules.logging import get_logger
 from src.modules.prompts.manager import PromptManager
 from src.modules.streaming.audio_stream_channel import AudioStreamChannel
 
+from src.modules.avatar.idle_motion_controller import IdleMotionController
 from src.stages.output.handlers.avatar.base import AvatarHandlerBase
 from src.stages.output.handlers.avatar.vts.expression_controller import ExpressionController
 from src.stages.output.handlers.avatar.vts.hotkey_matcher import HotkeyMatcher
@@ -66,6 +69,9 @@ class VTSHandler(AvatarHandlerBase):
     )
     _ACTION_KEYS = frozenset({"blink", "nod", "shake", "wave", "clap", "motion"})
 
+    # VTS 断线自动重连间隔（秒）：覆盖 Amaidesu 先于 VTS 启动、VTS 中途重启两种场景
+    _RECONNECT_INTERVAL_S = 5.0
+
     class _VTSActionParams(BaseModel):  # type: ignore[name-defined]  # noqa: F821
         duration_ms: int = Field(default=1500, ge=100, le=10000)
 
@@ -76,6 +82,17 @@ class VTSHandler(AvatarHandlerBase):
         "wave": _VTSActionParams,
         "clap": _VTSActionParams,
         "motion": _VTSActionParams,
+    }
+
+    # idle 动画参数名回退表：当配置名在 VTS 中不可用时，按此顺序尝试常见参数名。
+    # 若仍不匹配，会打印可用参数名提示用户手动配置。
+    _IDLE_PARAM_FALLBACKS: dict[str, tuple[str, ...]] = {
+        "head_x": ("HeadAngleX", "HeadX", "FaceAngleX", "FaceX", "NeckAngleX"),
+        "head_y": ("HeadAngleY", "HeadY", "FaceAngleY", "FaceY", "NeckAngleY"),
+        "head_z": ("HeadAngleZ", "HeadZ", "FaceAngleZ", "FaceZ", "NeckAngleZ"),
+        "body_x": ("BodyAngleX", "BodyX", "BodyRotationX", "TorsoAngleX", "BodyPositionX"),
+        "body_y": ("BodyAngleY", "BodyY", "BodyRotationY", "TorsoAngleY", "BodyPositionY"),
+        "body_z": ("BodyAngleZ", "BodyZ", "BodyRotationZ", "TorsoAngleZ", "BodyPositionZ"),
     }
 
     def get_capabilities(self):
@@ -113,6 +130,66 @@ class VTSHandler(AvatarHandlerBase):
         smoothing_factor: float = Field(default=0.3, ge=0.0, le=1.0, description="平滑因子")
         vowel_detection_sensitivity: float = Field(default=0.5, ge=0.0, le=1.0, description="元音检测灵敏度")
         sample_rate: int = Field(default=16000, ge=8000, le=48000, description="音频采样率")
+
+        # 口型自然度调参
+        volume_gain: float = Field(default=1.0, ge=0.1, le=3.0, description="音量增益（越大嘴张得越大）")
+        max_mouth_open: float = Field(default=0.6, ge=0.1, le=1.0, description="最大张嘴幅度上限，嘴型值域为 0~此值")
+        silence_threshold: float = Field(default=0.02, ge=0.0, le=1.0, description="静音阈值，低于此值直接闭嘴")
+        close_mouth_threshold: float = Field(
+            default=0.06, ge=0.0, le=1.0, description="低音量阈值，低于此值大幅衰减嘴型"
+        )
+        power_curve: float = Field(
+            default=1.0, ge=0.1, le=2.0, description="音量到嘴型的幂曲线（1.0=线性，>1 让嘴型更多分布在中低区间）"
+        )
+        vowel_open_weight: float = Field(default=0.5, ge=0.0, le=2.0, description="元音张嘴权重，降低可减少突跳")
+        update_interval_ms: float = Field(
+            default=30.0, ge=10.0, le=200.0, description="VTS 口型参数最小更新间隔（毫秒）"
+        )
+        mouth_open_lerp_speed: float = Field(
+            default=0.35, ge=0.05, le=1.0, description="嘴型向目标值过渡速度，越小越平滑"
+        )
+        vowel_decay: float = Field(default=0.4, ge=0.05, le=0.95, description="元音衰减速度，越小元音嘴型越连续")
+        min_mouth_delta: float = Field(default=0.005, ge=0.001, le=0.1, description="嘴型最小变化阈值，越小更新越连续")
+        base_smile: float = Field(
+            default=0.3,
+            ge=0.0,
+            le=1.0,
+            description="常驻微笑基线值：平时与说完话后保持的 MouthSmile；该模型的 EyeSmile 也由 MouthSmile 驱动，可让眼睛保持笑意",
+        )
+
+        # 默认 idle 动画配置（不说话时轻微摇头晃脑 + 身体移动）
+        idle_enabled: bool = Field(default=True, description="是否启用默认 idle 拟人动画")
+        idle_param_head_x: str = Field(default="HeadAngleX", description="头部左右摇头参数名")
+        idle_param_head_y: str = Field(default="HeadAngleY", description="头部上下点头参数名")
+        idle_param_head_z: str = Field(default="HeadAngleZ", description="头部倾斜/歪头参数名")
+        idle_param_body_x: str = Field(default="BodyX", description="身体左右移动参数名")
+        idle_param_body_y: str = Field(default="BodyY", description="身体上下移动参数名")
+        idle_param_body_z: str = Field(default="BodyZ", description="身体前后/深度移动参数名")
+        idle_head_amplitude: float = Field(
+            default=0.05, ge=0.0, le=30.0, description="头部晃动幅度（具体值域取决于模型 tracking 参数值域）"
+        )
+        idle_body_amplitude: float = Field(
+            default=0.02, ge=0.0, le=30.0, description="身体移动幅度（具体值域取决于模型 tracking 参数值域）"
+        )
+        idle_speed: float = Field(default=1.0, ge=0.1, le=5.0, description="idle 动画速度倍率")
+        idle_update_interval_ms: float = Field(default=40.0, ge=10.0, le=200.0, description="idle 参数更新间隔（毫秒）")
+        idle_fade_speed: float = Field(default=0.15, ge=0.01, le=1.0, description="说话/静默切换时 idle 平滑过渡速度")
+        idle_head_enabled: bool = Field(default=True, description="是否启用 idle 头部晃动")
+        idle_body_enabled: bool = Field(default=True, description="是否启用 idle 身体移动")
+        idle_pause_while_speaking: bool = Field(
+            default=False,
+            description="说话时是否暂停 idle 动画（默认 False，即始终运行）",
+        )
+        idle_extra_params: Dict[str, float] = Field(
+            default_factory=dict,
+            description="额外 idle 摆动参数（参数名 -> 幅度），如自定义袖子参数 SleeveRX/SleeveRY/SleeveLX/SleeveLY",
+        )
+        idle_extra_speed: Optional[float] = Field(
+            default=None,
+            ge=0.1,
+            le=5.0,
+            description="额外摆动参数（袖子等）的速度倍率；留空则跟随 idle_speed",
+        )
 
     def __init__(
         self,
@@ -154,11 +231,14 @@ class VTSHandler(AvatarHandlerBase):
         self._sticker_subscribed = False
 
         self._vts = None
+        self._vts_api_lock = asyncio.Lock()
         self._is_connecting = False
+        self._reconnect_task: Optional[asyncio.Task] = None
         self._vts_subscription_id: Optional[str] = None
 
         self.render_count = 0
         self.error_count = 0
+        self._current_intent_expressions: Dict[str, float] = {}
 
         self.lip_sync = LipSyncProcessor(
             logger_name=f"{self.__class__.__name__}.LipSync",
@@ -168,11 +248,26 @@ class VTSHandler(AvatarHandlerBase):
             vowel_detection_sensitivity=self.typed_config.vowel_detection_sensitivity,
             vts_set_parameter=self._expression_set_param_proxy,
             is_connected=lambda: self._is_connected,
+            volume_gain=self.typed_config.volume_gain,
+            max_mouth_open=self.typed_config.max_mouth_open,
+            silence_threshold=self.typed_config.silence_threshold,
+            close_mouth_threshold=self.typed_config.close_mouth_threshold,
+            power_curve=self.typed_config.power_curve,
+            vowel_open_weight=self.typed_config.vowel_open_weight,
+            update_interval_ms=self.typed_config.update_interval_ms,
+            mouth_open_lerp_speed=self.typed_config.mouth_open_lerp_speed,
+            vowel_decay=self.typed_config.vowel_decay,
+            min_mouth_delta=self.typed_config.min_mouth_delta,
+            expression_rest_values={
+                self.PARAM_MOUTH_SMILE: self.typed_config.base_smile,
+                self.PARAM_EYE_OPEN_LEFT: 1.0,
+                self.PARAM_EYE_OPEN_RIGHT: 1.0,
+            },
         )
         self.hotkey_matcher = HotkeyMatcher(
             logger_name=f"{self.__class__.__name__}.Hotkey",
             is_connected=lambda: self._is_connected,
-            vts_request=self._vts_request_proxy,
+            vts_request=self._make_vts_request_proxy(),
             prompt_service=self._prompt_service,
             openai_client=self._build_openai_client(),
             llm_model=self.typed_config.llm_model,
@@ -183,10 +278,81 @@ class VTSHandler(AvatarHandlerBase):
         self.expression = ExpressionController(
             logger_name=f"{self.__class__.__name__}.Expression",
             is_connected=lambda: self._is_connected,
-            vts_request=self._vts_request_proxy,
+            vts_request=self._make_vts_request_proxy(),
         )
+        self.idle_motion = IdleMotionController(
+            logger_name=f"{self.__class__.__name__}.IdleMotion",
+            is_connected=lambda: self._is_connected,
+            is_speaking=lambda: self.lip_sync.is_speaking,
+            set_parameter=self._idle_set_param_proxy,
+            param_head_x=self.typed_config.idle_param_head_x,
+            param_head_y=self.typed_config.idle_param_head_y,
+            param_head_z=self.typed_config.idle_param_head_z,
+            param_body_x=self.typed_config.idle_param_body_x,
+            param_body_y=self.typed_config.idle_param_body_y,
+            param_body_z=self.typed_config.idle_param_body_z,
+            head_amplitude=self.typed_config.idle_head_amplitude,
+            body_amplitude=self.typed_config.idle_body_amplitude,
+            speed=self.typed_config.idle_speed,
+            update_interval_ms=self.typed_config.idle_update_interval_ms,
+            fade_speed=self.typed_config.idle_fade_speed,
+            head_enabled=self.typed_config.idle_head_enabled,
+            body_enabled=self.typed_config.idle_body_enabled,
+            speech_pause_enabled=self.typed_config.idle_pause_while_speaking,
+            extra_params=self.typed_config.idle_extra_params,
+            extra_speed=self.typed_config.idle_extra_speed,
+        )
+        # 常驻微笑基线交给 idle 每 tick 维持，防止被外部覆盖（该模型 EyeSmile 也由 MouthSmile 驱动）
+        self.idle_motion.set_baseline_params({self.PARAM_MOUTH_SMILE: self.typed_config.base_smile})
 
         self.logger.info("VTSHandler初始化完成")
+
+    async def _idle_set_param_proxy(self, parameter_name: str, value: float) -> bool:
+        """idle 动画参数设置代理（静默写入，失败不刷屏）"""
+        if not parameter_name:
+            return False
+        return await self.expression.set_parameter(parameter_name, value, weight=1, silent=True)
+
+    async def _resolve_idle_parameter_names(self) -> dict[str, str]:
+        """根据 VTS 当前可用参数列表，为 idle 每个轴挑选可用参数名。
+
+        优先使用用户在配置中指定的名称；若不存在则按回退表尝试常见参数名；
+        若仍无匹配，会打印可用参数名并保留原配置名，便于用户排查。
+        """
+        available = set(await self.expression.list_tracking_parameters())
+        config_names = {
+            "head_x": self.typed_config.idle_param_head_x,
+            "head_y": self.typed_config.idle_param_head_y,
+            "head_z": self.typed_config.idle_param_head_z,
+            "body_x": self.typed_config.idle_param_body_x,
+            "body_y": self.typed_config.idle_param_body_y,
+            "body_z": self.typed_config.idle_param_body_z,
+        }
+        if not available:
+            self.logger.warning(
+                "无法获取 VTS 参数列表，idle 动画将使用配置中的参数名；"
+                "若模型无晃动，请运行 list_vts_params.py 查看可用参数名后修改 [handlers.vts].idle_* 配置。"
+            )
+            return config_names
+
+        resolved: dict[str, str] = {}
+        for axis, user_name in config_names.items():
+            candidates = (user_name,) + self._IDLE_PARAM_FALLBACKS.get(axis, ())
+            chosen = next((name for name in candidates if name in available), None)
+            if chosen:
+                resolved[axis] = chosen
+                if chosen != user_name:
+                    self.logger.info(f"idle 参数回退：{axis} 配置名 '{user_name}' 在 VTS 中不可用，自动使用 '{chosen}'")
+            else:
+                resolved[axis] = user_name
+                available_sample = sorted(available)[:30]
+                self.logger.warning(
+                    f"idle 参数 {axis} 在 VTS 中无可用候选（配置名 '{user_name}'，"
+                    f"回退表 {candidates} 均不可用）。"
+                    f"当前可用参数示例：{available_sample}。"
+                    f"请在 config/output.toml [handlers.vts] 中把 idle_param_{axis} 改为实际可用参数名。"
+                )
+        return resolved
 
     def _build_openai_client(self) -> Optional[Any]:
         if not (self.typed_config.llm_matching_enabled and LLM_AVAILABLE and self.typed_config.llm_api_key):
@@ -202,14 +368,39 @@ class VTSHandler(AvatarHandlerBase):
             self.logger.warning(f"LLM客户端初始化失败: {e}")
             return None
 
-    def _vts_request_proxy(self, request) -> Coroutine[Any, Any, Any]:
-        return self._vts.request(request)
+    def _make_vts_request_proxy(self):
+        """创建一个可调用代理，既支持发送 request，又暴露 pyvts 的 request 构造方法。
+
+        所有 VTS API 调用都经过同一把 asyncio.Lock 串行化：pyvts 的 websocket
+        连接不支持并发 recv，idle 动画（25Hz）与口型同步（33Hz）同时写入时会
+        抛出 "cannot call recv while another coroutine is already running recv"。
+        """
+        import pyvts
+
+        handler = self
+        vts_request_builder = pyvts.VTSRequest()
+
+        class VTSRequestProxy:
+            async def __call__(self, request):
+                async with handler._vts_api_lock:
+                    return await handler._vts.request(request)
+
+            @property
+            def vts_request(self):
+                return vts_request_builder
+
+            def requestHotKeyList(self):
+                return vts_request_builder.requestHotKeyList()
+
+            def requestTriggerHotKey(self, **kwargs):
+                return vts_request_builder.requestTriggerHotKey(**kwargs)
+
+        return VTSRequestProxy()
 
     async def _expression_set_param_proxy(self, parameter_name: str, value: float, weight: float = 1) -> bool:
         return await self.expression.set_parameter(parameter_name, value, weight)
 
     async def init(self):
-        await super().init()
         try:
             import pyvts  # noqa: F401
             from pyvts import vts
@@ -233,6 +424,13 @@ class VTSHandler(AvatarHandlerBase):
             self.logger.error("pyvts库不可用，VTSHandler将被禁用")
             self._vts = None
             raise ImportError("pyvts library not available") from None
+
+        # 必须先创建 _vts 再调 super().init()，因为 base 的 init 内部会调用 _connect()
+        await super().init()
+
+        # 启动断线自动重连循环（VTS 后启动/中途重启都能自动恢复）
+        self._reconnect_task = asyncio.create_task(self._reconnect_loop())
+        self._reconnect_task.set_name(f"{self.__class__.__name__}.reconnect_loop")
 
         if self.event_bus and not getattr(self, "_sticker_subscribed", False):
             from src.modules.events.payloads import StickerCommandPayload
@@ -272,6 +470,12 @@ class VTSHandler(AvatarHandlerBase):
             else:
                 return None
 
+        # 把当前 emotion 对应的基础表情同步给 LipSync，让它在说话时保持、结束后淡出
+        self._current_intent_expressions = dict(result["expressions"])
+        self.lip_sync.set_base_expressions(self._current_intent_expressions)
+        # 同步给 idle：Intent 占用的表情参数不写入常驻基线，避免互相覆盖
+        self.idle_motion.set_baseline_overrides(self._current_intent_expressions)
+
         self.logger.debug(f"Intent适配结果: expressions={result['expressions']}, hotkeys={result['hotkeys']}")
         return result
 
@@ -302,7 +506,12 @@ class VTSHandler(AvatarHandlerBase):
 
     async def _render_to_platform(self, params: Dict[str, Any]) -> None:
         try:
+            # 表情参数由 LipSync 在说话期间统一维持/淡出，避免重复设置造成冲突。
+            # 但 LipSync 只会在音频流开始后接管；如果当前没有音频流，仍然直接设置一次。
+            has_audio_stream = self.audio_stream_channel is not None
             for param_name, value in params.get("expressions", {}).items():
+                if has_audio_stream and self.lip_sync.is_speaking:
+                    continue
                 await self.expression.set_parameter(param_name, float(value), weight=1)
             for hotkey in params.get("hotkeys", []):
                 await self.hotkey_matcher.trigger_hotkey(hotkey)
@@ -325,19 +534,48 @@ class VTSHandler(AvatarHandlerBase):
 
             self.logger.info(f"开始连接VTS: {self.vts_host}:{self.vts_port}")
             await self._vts.connect()
-            await self._vts.request_authentication_token()
-            await self._vts.request_authentication()
+            await self._vts.request_authenticate_token()
+            await self._vts.request_authenticate()
             self._is_connected = True
             self.logger.info("VTS连接成功")
 
             await self.hotkey_matcher.load_hotkeys()
 
+            # 连接成功后解析 VTS 可用参数名，把 idle 参数回退到实际存在的参数
+            resolved = await self._resolve_idle_parameter_names()
+            self.idle_motion.set_parameter_names(
+                param_head_x=resolved.get("head_x"),
+                param_head_y=resolved.get("head_y"),
+                param_head_z=resolved.get("head_z"),
+                param_body_x=resolved.get("body_x"),
+                param_body_y=resolved.get("body_y"),
+                param_body_z=resolved.get("body_z"),
+            )
+
+            if self.typed_config.idle_enabled:
+                try:
+                    self.idle_motion.start()
+                    self.logger.info("VTS idle 动画已启动")
+                except Exception as e:
+                    self.logger.error(f"启动 idle 动画失败: {e}")
+
+            # 应用常驻微笑基线（该模型 MouthSmile 同时驱动 EyeSmile，让眼睛保持笑意）
+            try:
+                await self.expression.set_parameter(
+                    self.PARAM_MOUTH_SMILE, self.typed_config.base_smile, weight=1, silent=True
+                )
+            except Exception as e:
+                self.logger.warning(f"应用常驻微笑基线失败: {e}")
+
             if self.audio_stream_channel and not self._vts_subscription_id:
+                from src.modules.streaming.backpressure import SubscriberConfig
+
                 self._vts_subscription_id = await self.audio_stream_channel.subscribe(
                     name="vts_lip_sync",
                     on_audio_start=self.lip_sync.on_start,
                     on_audio_chunk=self.lip_sync.on_chunk,
                     on_audio_end=self.lip_sync.on_end,
+                    config=SubscriberConfig(queue_size=500, backpressure_strategy="drop_oldest"),
                 )
                 self.logger.info("VTS已订阅 AudioStreamChannel")
         except Exception as e:
@@ -346,7 +584,57 @@ class VTSHandler(AvatarHandlerBase):
         finally:
             self._is_connecting = False
 
+    async def _vts_health_check(self) -> bool:
+        """轻量健康检查：连接可能已随 VTS 重启而静默断开"""
+        try:
+            proxy = self._make_vts_request_proxy()
+            response = await asyncio.wait_for(
+                proxy(proxy.vts_request.requestParameterValue("FaceAngleX")),
+                timeout=3.0,
+            )
+            return bool(response and response.get("messageType") == "ParameterValueResponse")
+        except Exception:
+            return False
+
+    async def _reconnect_loop(self) -> None:
+        """VTS 断线自动重连：未连接时定期重试；已连接时定期健康检查，断开则重连。"""
+        try:
+            while True:
+                await asyncio.sleep(self._RECONNECT_INTERVAL_S)
+                if self._is_connecting:
+                    continue
+                if not self._is_connected:
+                    self.logger.info("VTS 未连接，尝试自动重连...")
+                    await self._connect()
+                    continue
+                if not await self._vts_health_check():
+                    self.logger.warning("VTS 连接已断开（VTS 可能已重启），准备自动重连")
+                    self._is_connected = False
+                    try:
+                        await self._vts.close()
+                    except Exception as e:
+                        self.logger.debug(f"关闭旧 VTS 连接异常（忽略）: {e}")
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self.logger.error(f"VTS 自动重连循环异常: {e}", exc_info=True)
+
     async def _disconnect(self) -> None:
+        # 先停自动重连，避免清理过程中又连上
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except asyncio.CancelledError:
+                pass
+        self._reconnect_task = None
+
+        # 先停止 idle 动画，避免在断连期间还尝试写参数
+        try:
+            await self.idle_motion.stop()
+        except Exception as e:
+            self.logger.warning(f"停止 idle 动画失败: {e}")
+
         if self._vts_subscription_id and self.audio_stream_channel:
             try:
                 await self.audio_stream_channel.unsubscribe(self._vts_subscription_id)

--- a/tests/modules/avatar/test_idle_motion_controller.py
+++ b/tests/modules/avatar/test_idle_motion_controller.py
@@ -1,0 +1,339 @@
+"""
+IdleMotionController 测试
+"""
+
+import asyncio
+
+import pytest
+
+from src.modules.avatar.idle_motion_controller import IdleMotionController
+
+
+@pytest.fixture
+def controller():
+    """创建带模拟回调的 IdleMotionController"""
+    calls = []
+
+    async def set_param(name, value):
+        calls.append((name, value))
+        return True
+
+    return (
+        IdleMotionController(
+            logger_name="TestIdleMotion",
+            is_connected=lambda: True,
+            is_speaking=lambda: False,
+            set_parameter=set_param,
+            param_head_x="HeadX",
+            param_head_y="HeadY",
+            param_head_z="HeadZ",
+            param_body_x="BodyX",
+            param_body_y="BodyY",
+            param_body_z="BodyZ",
+            head_amplitude=0.1,
+            body_amplitude=0.05,
+            speed=1.0,
+            update_interval_ms=20.0,
+            fade_speed=0.5,
+        ),
+        calls,
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_stop_and_params_are_sent(controller):
+    """启动后应持续发送参数，停止后归零"""
+    ctrl, calls = controller
+    ctrl.start()
+    await asyncio.sleep(0.08)
+    await ctrl.stop()
+
+    head_names = {c[0] for c in calls if c[0].startswith("Head")}
+    body_names = {c[0] for c in calls if c[0].startswith("Body")}
+    assert head_names == {"HeadX", "HeadY", "HeadZ"}
+    assert body_names == {"BodyX", "BodyY", "BodyZ"}
+
+    # 停止后参数归零
+    zero_values = {c[0]: c[1] for c in calls if c[0] in head_names | body_names and c[1] == 0.0}
+    assert len(zero_values) >= 6
+
+
+@pytest.mark.asyncio
+async def test_speaking_pauses_idle(controller):
+    """说话期间 idle 应暂停/衰减"""
+    speaking = True
+
+    async def set_param(name, value):
+        return True
+
+    ctrl = IdleMotionController(
+        logger_name="TestIdleMotionSpeaking",
+        is_connected=lambda: True,
+        is_speaking=lambda: speaking,
+        set_parameter=set_param,
+        head_amplitude=0.1,
+        body_amplitude=0.05,
+        update_interval_ms=20.0,
+        fade_speed=0.5,
+    )
+    ctrl.start()
+    await asyncio.sleep(0.08)
+    await ctrl.stop()
+
+    # 只要说话期间不出异常即可；停止时归零
+    assert not ctrl._running
+
+
+@pytest.mark.parametrize(
+    "speech_pause_enabled, expect_nonzero",
+    [
+        (True, False),  # 默认：说话期间暂停 idle
+        (False, True),  # 配置为 False：说话期间继续 idle
+    ],
+)
+@pytest.mark.asyncio
+async def test_speech_pause_flag(speech_pause_enabled, expect_nonzero):
+    """说话时是否暂停 idle 取决于 speech_pause_enabled 开关"""
+    speaking = True
+    calls = []
+
+    async def set_param(name, value):
+        calls.append((name, value))
+        return True
+
+    ctrl = IdleMotionController(
+        logger_name="TestIdleMotionSpeechFlag",
+        is_connected=lambda: True,
+        is_speaking=lambda: speaking,
+        set_parameter=set_param,
+        head_amplitude=1.0,
+        body_amplitude=1.0,
+        update_interval_ms=20.0,
+        fade_speed=0.5,
+        speech_pause_enabled=speech_pause_enabled,
+    )
+    ctrl.start()
+    await asyncio.sleep(0.6)
+    await ctrl.stop()
+
+    max_abs = max((abs(v) for _, v in calls), default=0.0)
+    if expect_nonzero:
+        assert max_abs > 0.001, "speech_pause_enabled=False 时说话期间仍应继续产生 idle 动作"
+    else:
+        assert max_abs <= 0.001, "speech_pause_enabled=True 时说话期间 idle 应暂停归零"
+
+
+@pytest.mark.asyncio
+async def test_set_parameter_names_updates_targets():
+    """动态更新参数名后，应写入新参数名并重置状态"""
+    calls = []
+
+    async def set_param(name, value):
+        calls.append((name, value))
+        return True
+
+    ctrl = IdleMotionController(
+        logger_name="TestIdleMotionRename",
+        is_connected=lambda: True,
+        is_speaking=lambda: False,
+        set_parameter=set_param,
+        param_head_x="HeadX",
+        head_amplitude=1.0,
+        update_interval_ms=20.0,
+        fade_speed=0.5,
+    )
+
+    ctrl.set_parameter_names(param_head_x="NewHeadX", param_head_y="NewHeadY")
+    ctrl.start()
+    await asyncio.sleep(0.06)
+    await ctrl.stop()
+
+    head_names = {c[0] for c in calls if c[0].startswith("NewHead")}
+    assert head_names == {"NewHeadX", "NewHeadY"}
+    assert "HeadX" not in {c[0] for c in calls}
+
+
+@pytest.mark.asyncio
+async def test_shared_head_body_params_are_merged():
+    """head/body 使用相同参数名时，body 信号应叠加合并而不是覆盖 head"""
+    import random
+
+    calls = []
+
+    async def set_param(name, value):
+        calls.append((name, value))
+        return True
+
+    ctrl = IdleMotionController(
+        logger_name="TestIdleMotionShared",
+        is_connected=lambda: True,
+        is_speaking=lambda: False,
+        set_parameter=set_param,
+        param_head_x="FaceAngleX",
+        param_head_y="FaceAngleY",
+        param_head_z="FaceAngleZ",
+        param_body_x="FaceAngleX",
+        param_body_y="FaceAngleY",
+        param_body_z="FaceAngleZ",
+        head_amplitude=3.0,
+        body_amplitude=1.0,
+        update_interval_ms=20.0,
+        fade_speed=0.5,
+        rng=random.Random(7),
+    )
+
+    targets = ctrl._compute_targets()
+    # 同名参数合并后只出现一次
+    assert set(targets.keys()) == {"FaceAngleX", "FaceAngleY", "FaceAngleZ"}
+    # 合并值不超过钳制上限 head_amplitude + body_amplitude
+    limit = 3.0 + 1.0
+    for value in targets.values():
+        assert abs(value) <= limit
+
+    # 采样多个时间点：合并后应保留 head 分量（若被 body 覆盖，幅度超不过 body_amplitude=1.0）
+    import time as _time
+
+    samples = []
+    for k in range(20):
+        ctrl._start_time = _time.time() - k * 1.3
+        samples.append(abs(ctrl._compute_targets()["FaceAngleX"]))
+    assert max(samples) > 1.0, "head/body 共享参数时应保留 head 分量，而不是被 body 覆盖"
+
+    # 端到端：循环写入时每个共享参数只写一次，且停止后归零
+    ctrl.start()
+    await asyncio.sleep(0.6)
+    await ctrl.stop()
+
+    names = {c[0] for c in calls}
+    assert names == {"FaceAngleX", "FaceAngleY", "FaceAngleZ"}
+
+
+def test_merge_target_only_combines_existing_names():
+    """_merge_target：参数名未被 head 占用时保持原行为（直接写入）"""
+
+    async def set_param(name, value):
+        return True
+
+    ctrl = IdleMotionController(
+        logger_name="TestIdleMotionMerge",
+        is_connected=lambda: True,
+        is_speaking=lambda: False,
+        set_parameter=set_param,
+        head_amplitude=3.0,
+        body_amplitude=1.0,
+    )
+
+    targets = {"HeadX": 2.0}
+    # 已存在的参数名：叠加并钳制
+    ctrl._merge_target(targets, "HeadX", 2.0)
+    assert targets["HeadX"] == 4.0  # 未超上限 3.0+1.0，直接相加
+    ctrl._merge_target(targets, "HeadX", 2.0)
+    assert targets["HeadX"] == 4.0  # 超过上限，钳制到 4.0
+    # 未占用的参数名：直接写入（可为负）
+    ctrl._merge_target(targets, "BodyX", -0.5)
+    assert targets["BodyX"] == -0.5
+    # 空参数名忽略
+    ctrl._merge_target(targets, "", 1.0)
+    assert "" not in targets
+
+
+@pytest.mark.asyncio
+async def test_extra_params_are_swayed_independently():
+    """extra_params（如袖子参数）应参与 idle 摆动，幅度独立且不超过配置值"""
+    calls = []
+
+    async def set_param(name, value):
+        calls.append((name, value))
+        return True
+
+    ctrl = IdleMotionController(
+        logger_name="TestIdleMotionExtra",
+        is_connected=lambda: True,
+        is_speaking=lambda: False,
+        set_parameter=set_param,
+        head_amplitude=7.0,
+        body_amplitude=5.0,
+        update_interval_ms=20.0,
+        fade_speed=0.5,
+        extra_params={"SleeveRX": 3.0, "SleeveRY": 2.0},
+    )
+
+    targets = ctrl._compute_targets()
+    assert "SleeveRX" in targets and "SleeveRY" in targets
+    assert abs(targets["SleeveRX"]) <= 3.0
+    assert abs(targets["SleeveRY"]) <= 2.0
+
+    ctrl.start()
+    await asyncio.sleep(0.08)
+    await ctrl.stop()
+
+    sleeve_values = [abs(v) for n, v in calls if n == "SleeveRX"]
+    assert sleeve_values, "SleeveRX 应被持续写入"
+    assert max(sleeve_values) <= 3.0
+    # 停止后归零
+    zero_names = {n for n, v in calls if v == 0.0}
+    assert "SleeveRX" in zero_names and "SleeveRY" in zero_names
+
+
+def test_axis_wander_irregular_rhythm():
+    """AxisWander：输出有界、存在随机停留（连续不变），且整体有运动"""
+    import random
+
+    from src.modules.avatar.idle_motion_controller import AxisWander
+
+    w = AxisWander(
+        random.Random(42),
+        min_duration=0.5,
+        max_duration=1.5,
+        pause_probability=0.8,
+        max_pause=1.0,
+    )
+    dt = 0.05
+    values = [w.value(k * dt) for k in range(400)]  # 20 秒
+
+    # 输出始终在归一化范围内
+    assert all(-1.0 <= v <= 1.0 for v in values)
+    # 有运动
+    assert max(values) - min(values) > 0.3
+    # 存在停留：至少一段连续 3 个采样值完全相同（pause 期间保持目标值）
+    run = 1
+    max_run = 1
+    for a, b in zip(values, values[1:]):
+        run = run + 1 if a == b else 1
+        max_run = max(max_run, run)
+    assert max_run >= 3, "应存在随机停留（连续不变的时间段）"
+
+
+def test_baseline_params_maintained_and_skipped():
+    """常驻基线参数：闲置时写入；说话或被 Intent 占用时跳过"""
+    import random
+
+    async def set_param(name, value):
+        return True
+
+    ctrl = IdleMotionController(
+        logger_name="TestIdleMotionBaseline",
+        is_connected=lambda: True,
+        is_speaking=lambda: False,
+        set_parameter=set_param,
+        rng=random.Random(1),
+    )
+    ctrl.set_baseline_params({"MouthSmile": 0.3})
+
+    # 闲置：基线写入
+    targets = ctrl._compute_targets(speaking=False)
+    assert targets["MouthSmile"] == 0.3
+
+    # 说话：基线跳过（表情由 LipSync 接管）
+    targets = ctrl._compute_targets(speaking=True)
+    assert "MouthSmile" not in targets
+
+    # Intent 占用 MouthSmile（如 happy=1.0）：基线跳过
+    ctrl.set_baseline_overrides({"MouthSmile": 1.0})
+    targets = ctrl._compute_targets(speaking=False)
+    assert "MouthSmile" not in targets
+
+    # Intent 清空（neutral）：基线恢复
+    ctrl.set_baseline_overrides({})
+    targets = ctrl._compute_targets(speaking=False)
+    assert targets["MouthSmile"] == 0.3

--- a/tests/stages/output/handlers/avatar/vts/test_lip_sync_rest_values.py
+++ b/tests/stages/output/handlers/avatar/vts/test_lip_sync_rest_values.py
@@ -1,0 +1,110 @@
+"""
+LipSyncProcessor 表情静止值（rest values）测试
+
+说话结束后，表情参数应淡出到静止值（EyeOpen=1.0 睁眼、MouthSmile=常驻微笑），
+而不是一律归零（归零会导致闭眼/撇嘴约 1 秒才恢复）。
+"""
+
+import pytest
+
+from src.stages.output.handlers.avatar.vts.lip_sync_processor import LipSyncProcessor
+
+
+@pytest.fixture
+def processor():
+    """创建带模拟回调与静止值的 LipSyncProcessor"""
+    calls = []
+
+    async def set_param(name, value, weight=1):
+        calls.append((name, value))
+        return True
+
+    proc = LipSyncProcessor(
+        logger_name="TestLipSync",
+        sample_rate=16000,
+        volume_threshold=0.01,
+        smoothing_factor=0.3,
+        vowel_detection_sensitivity=0.5,
+        vts_set_parameter=set_param,
+        is_connected=lambda: True,
+        expression_rest_values={"MouthSmile": 0.3, "EyeOpenLeft": 1.0, "EyeOpenRight": 1.0},
+    )
+    return proc, calls
+
+
+@pytest.mark.asyncio
+async def test_stop_session_returns_to_rest_values(processor):
+    """stop_session 后 MouthOpen 归零，表情参数回到静止值而不是 0"""
+    proc, calls = processor
+    proc.set_base_expressions({"MouthSmile": 1.0, "EyeOpenLeft": 1.0, "MouthOpen": 0.5})
+
+    await proc.start_session("测试")
+    # 模拟说话期间基础表情被推到目标值
+    proc._current_expression_values["MouthSmile"] = 1.0
+    proc._current_expression_values["EyeOpenLeft"] = 1.0
+    await proc.stop_session()
+
+    last_values = {}
+    for name, value in calls:
+        last_values[name] = value
+
+    # MouthOpen 被 set_base_expressions 过滤，最终闭嘴
+    assert last_values.get("MouthOpen") == 0.0
+    # 表情参数淡出到静止值而不是 0
+    assert last_values.get("MouthSmile") == pytest.approx(0.3, abs=0.01)
+    # EyeOpenLeft 静止值就是 1.0（保持睁眼，不会被拉到 0）
+    assert last_values.get("EyeOpenLeft", 1.0) == pytest.approx(1.0, abs=0.01)
+    # 整个淡出过程中 EyeOpenLeft 不应出现接近 0（闭眼）的值
+    eye_values = [v for n, v in calls if n == "EyeOpenLeft"]
+    assert all(v > 0.5 for v in eye_values)
+
+
+def test_has_active_expressions_compares_against_rest(processor):
+    """_has_active_expressions 应与静止值比较：等于静止值即视为不活跃"""
+    proc, _ = processor
+    proc._current_expression_values = {"MouthSmile": 0.3, "EyeOpenLeft": 1.0}
+    assert not proc._has_active_expressions()
+
+    proc._current_expression_values = {"MouthSmile": 0.8, "EyeOpenLeft": 1.0}
+    assert proc._has_active_expressions()
+
+    # 未配置静止值的参数仍以 0 为基准
+    proc._current_expression_values = {"Brows": 0.0}
+    assert not proc._has_active_expressions()
+    proc._current_expression_values = {"Brows": 0.5}
+    assert proc._has_active_expressions()
+
+
+@pytest.mark.asyncio
+async def test_fade_targets_rest_values_when_not_speaking(processor):
+    """静音/结束时 _update_base_expressions 的淡出目标是静止值"""
+    proc, calls = processor
+    proc.set_base_expressions({"MouthSmile": 1.0})
+    proc._current_expression_values["MouthSmile"] = 1.0
+    proc.is_speaking = False
+
+    await proc._update_base_expressions(volume=0.0)
+
+    # 当前值应向静止值 0.3 移动，而不是向 0 移动
+    current = proc._current_expression_values["MouthSmile"]
+    assert current < 1.0
+    assert current > 0.3
+
+
+def test_default_rest_value_is_zero():
+    """不传 expression_rest_values 时，静止值默认为 0（向后兼容）"""
+
+    async def set_param(name, value, weight=1):
+        return True
+
+    proc = LipSyncProcessor(
+        logger_name="TestLipSyncDefault",
+        sample_rate=16000,
+        volume_threshold=0.01,
+        smoothing_factor=0.3,
+        vowel_detection_sensitivity=0.5,
+        vts_set_parameter=set_param,
+        is_connected=lambda: True,
+    )
+    assert proc._rest_value("MouthSmile") == 0.0
+    assert proc._rest_value("EyeOpenLeft") == 0.0


### PR DESCRIPTION
## 改动
- 新增 IdleMotionController / AxisWander：随机目标 + 随机时长 + 随机停留的拟人 idle 动画（替代固定频率正弦），支持头身联动耦合、自定义扩展参数（如模型部件摆动）、同名 tracking 参数合并写入
- LipSyncProcessor：说话结束后表情淡出到可配置的静止基线（EyeOpen 保持睁眼、MouthSmile 保持 base_smile），修复闭眼/撇嘴问题
- VTSHandler：新增断线自动重连循环（每 5s 健康检查，VTS 未启动/中途重启均可自动恢复并重订阅口型通道）；VTS API 调用加锁串行化，修复 websocket 并发 recv 竞态
- 修复 VTS 参数列表响应解析（InputParameterListResponse 的 defaultParameters/customParameters），idle 参数名可自动回退到可用参数
- AudioStreamChannel：为每个订阅者启动独立消费者 task，保证音频块可靠送达口型订阅者

## 测试
- 新增 7 个测试用例（随机漫步节奏、参数合并、基线写入/跳过）；本分支 pytest 1232 passed（另有 26 个 upstream/dev 既有失败，与本 PR 无关，已在干净 upstream/dev 上复核）
- ruff check / format 通过
- 已在 VTube Studio 真机验证：待机随机晃动、TTS 口型同步、说完回基线、VTS 重启后自动恢复